### PR TITLE
Git20 corrected graph depency loop

### DIFF
--- a/src/main/java/io/openliberty/elph/bnd/BndCatalog.java
+++ b/src/main/java/io/openliberty/elph/bnd/BndCatalog.java
@@ -118,7 +118,10 @@ public class BndCatalog {
         synchronized (this) {
             if (bndQueried) return;
             var bnd = new BndWorkspace(io, root, nameIndex::get);
-            digraph.vertexSet().forEach(p -> bnd.getBuildAndTestDependencies(p).forEach(q -> digraph.addEdge(p,q)));
+            digraph.vertexSet().forEach(p -> bnd
+                    .getBuildAndTestDependencies(p)
+                    .filter(not(p::equals))
+                    .forEach(q -> digraph.addEdge(p,q)));
             var text = digraph.edgeSet()
                     .stream()
                     .map(this::formatEdge)


### PR DESCRIPTION
resolves #20 
The issue was because when adding the depencies, if a project had itself as a depency, it would still add an edge between theum, thus creating a loop