### PR TITLE
Missing Eclipse executable causes error on validation

### DIFF
--- a/src/main/java/io/openliberty/elph/cmd/ElphCommand.java
+++ b/src/main/java/io/openliberty/elph/cmd/ElphCommand.java
@@ -87,7 +87,7 @@ public class ElphCommand {
         this.eclipseHome = path;
         if (!Files.isDirectory(eclipseHome)) io.warn("Eclipse Home is not a valid " + (OS.is(MAC) ? "app" : "directory") + ": " + olRepo);
         else if (OS.is(MAC) && !eclipseHome.toString().endsWith(".app")) io.warn("Eclipse Home is a directory but not a .app directory");
-        else if (!Files.isExecutable(eclipseHome.resolve(OS.current().pathToExecutable))) throw io.error("Eclipse Home does not contain an executable in the expected place: " + eclipseHome.resolve(OS.current().pathToExecutable));
+        else if (!Files.isExecutable(eclipseHome.resolve(OS.current().pathToExecutable))) io.warn("Eclipse Home does not contain an executable in the expected place: " + eclipseHome.resolve(OS.current().pathToExecutable));
     }
     @Option(names = {"-w", "--workspace"}, paramLabel = "PATH", hidden = true)
     void setEclipseWorkspace(Path path) {


### PR DESCRIPTION
- Update README.md
- Issue only warnings when validating setup
